### PR TITLE
Fix completion if word-to-complete contains colon (:)

### DIFF
--- a/phake_completion.sh
+++ b/phake_completion.sh
@@ -4,19 +4,14 @@ _phake()
     COMPREPLY=()
 
     local cur prev
-    cur="${COMP_WORDS[COMP_CWORD]}"
-    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    _get_comp_words_by_ref -n : cur prev
 
     local opts
     opts=`phake -T | awk 'BEGIN {x=1}; $x>1 {print $1}'`
-    optscolon=${cur%"${cur##*:}"}
 
     COMPREPLY=( $(compgen -W "${opts}"  -- ${cur}))
 
-    local i=${#COMPREPLY[*]}
-    while [ $((--i)) -ge 0 ]; do
-        COMPREPLY[$i]=${COMPREPLY[$i]#"$optscolon"}
-    done
+    __ltrim_colon_completions "$cur"
 }
 
 complete -F _phake phake


### PR DESCRIPTION
The recommended way to handle colons in completion words
is by using the helper methods:
- _get_comp_words_by_ref with the -n : option
    gets the word-to-complete without considering a colon as a word break
- __ltrim_colon_completions
    removes colon containing prefix from COMPREPLY items
    (a workaround for http://tiswww.case.edu/php/chet/bash/FAQ - E13)

Using the helper methods also simplifies the script and
ensures that we get the same behavior on any environment.

Tested on Ubuntu 12.04, Red Hat 5 and 6.
