### PR TITLE
Problems with posix_isatty

### DIFF
--- a/lib/utils.php
+++ b/lib/utils.php
@@ -38,5 +38,5 @@ function fatal($exception, $message = null) {
 }
 
 function is_tty() {
-    return posix_isatty(STDOUT);
+    return function_exists('posix_isatty') ? posix_isatty(STDOUT) : false;
 }


### PR DESCRIPTION
I have some PHP installations that don't have the posix extension installed, so whenever there is any output that checks to see if it should include ANSI characters or not, there is a fatal error.

This pull request basically assumes that STDOUT is not a tty if the function doesn't exist in the first place.
