### PR TITLE
Do not chdir() to phakefile directory

### DIFF
--- a/lib/phake/Bin.php
+++ b/lib/phake/Bin.php
@@ -67,11 +67,7 @@ class Bin
                 $runfile = $builder->resolve_runfile(getcwd());
                 $directory = dirname($runfile);
 
-                if (!@chdir($directory)) {
-                    throw new Exception("Couldn't change to directory '$directory'");
-                } else {
-                    echo "(in $directory)\n";
-                }
+                echo "(in $directory)\n";
             }
 
             $builder->load_runfile($runfile);


### PR DESCRIPTION
This is done in order to preserve relative path passed as arguments, as
they're relative to the current working directory.

Consider the directory structure:

```
project/
|- demo/
|   \- example.txt
\- Phakefile.php
```

Consider I have a task named `test` which accepts a single argument `file`:
- If I'm in the directory `project/`, I expect to be able to run `phake test file=demo/example.txt`
- If I'm in the directory `project/demo`, I expect to be able to run `phake test file=example.txt`

Open for discussion:
- What was the original rational for changing dirs? (What about rake / make?)
- Is this considered a BC break, and if so, how should this be handled?
