### PR TITLE
Fix checking parent folders for Phakefile

### DIFF
--- a/lib/phake/Builder.php
+++ b/lib/phake/Builder.php
@@ -72,20 +72,21 @@ class Builder
     }
 
     public function resolve_runfile($directory) {
-        $directory = rtrim($directory, '/') . '/';
+        $directory = rtrim($directory, '/');
         $runfiles = array('Phakefile', 'Phakefile.php');
+
         do {
             foreach ($runfiles as $r) {
-                $candidate = $directory . $r;
+                $candidate = $directory . '/' . $r;
                 if (file_exists($candidate)) {
                     return $candidate;
                 }
             }
-            if ($directory == '/') {
-                throw new \Exception("No Phakefile found");
-            }
+            $previous  = $directory;
             $directory = dirname($directory);
-        } while (true);
+        } while ($directory !== $previous);
+
+        throw new \Exception("No Phakefile found");
     }
 
     public function load_runfile($file) {

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -24,6 +24,63 @@ class BuilderTest extends TestCase
         $builder->load_runfile('does not exist');
     }
 
+    /**
+     * @dataProvider provideResolveRunfile
+     */
+    public function testResolveRunfile($search, $expected)
+    {
+        $builder = new Builder();
+
+        $this->assertEquals($expected, $builder->resolve_runfile($search));
+    }
+
+    public function provideResolveRunfile()
+    {
+        $root = __DIR__ . '/..';
+
+        return array(
+            array(
+                $root,
+                $root . '/Phakefile'
+            ),
+            array(
+                $root . '/bin',
+                $root . '/Phakefile'
+            ),
+            array(
+                $root . '/example',
+                $root . '/example/Phakefile'
+            ),
+            array(
+                $root . '/lib/phake',
+                $root . '/Phakefile'
+            )
+        );
+    }
+
+    /**
+     * @expectedException Exception
+     * @dataProvider provideResolveRunfileNonExistant
+     */
+    public function testResolveRunfileNonExistant($path)
+    {
+        $builder = new Builder();
+
+        $builder->resolve_runfile($path);
+    }
+
+    public function provideResolveRunfileNonExistant()
+    {
+        return array(
+            array(
+                realpath('../../')
+            ),
+            array(
+                realpath(__DIR__ . '/../..')
+            ),
+        );
+    }
+
     public function testEmpty()
     {
         $builder = new Builder();


### PR DESCRIPTION
Currently, phake fails to find a Phakefile in any of its parent directories.

Bug introduced with 6360aee47493e87d44aaeb6064c717a81e11111d
