### PR TITLE
Return null from Application::offsetGet if argument doesn't exist

### DIFF
--- a/lib/phake/Application.php
+++ b/lib/phake/Application.php
@@ -63,7 +63,7 @@ class Application implements \ArrayAccess, \IteratorAggregate
     }
 
     public function offsetGet($k) {
-        return $this->args[$k];
+        return isset($this->args[$k]) ? $this->args[$k] : null;
     }
 
     public function offsetSet($k, $v) {


### PR DESCRIPTION
This patch prevents an error from being triggered if there's an attempt to access an argument that doesn't exist. This helps calling code to not require isset checks every time an argument is accessed.
