### PR TITLE
Removed error with <= PHP 5.3.3-7 on debian

### DIFF
--- a/lib/phake/Bin.php
+++ b/lib/phake/Bin.php
@@ -119,7 +119,8 @@ class Bin
     }
 
     private function detect_and_display_cycles($application) {
-        $cycles = (new CycleDetector($application->root()))->get_cycles();
+        $cycleDetector = new CycleDetector($application->root());
+        $cycles = $cycleDetector->get_cycles();
         if (empty($cycles)) {
             return false;
         }


### PR DESCRIPTION
PHP 5.3.3-7 on debian throwed "syntax error, unexpected T_OBJECT_OPERATOR" on line 122 in lib/phake/Bin.php - fixed this problem by assigning the temporary object to a variable before use.
