### PR TITLE
Fixes #58 TaskNotFoundException error message is missing task name.

### DIFF
--- a/lib/phake/Bin.php
+++ b/lib/phake/Bin.php
@@ -112,7 +112,7 @@ class Bin
             }
 
         } catch (TaskNotFoundException $tnfe) {
-            $this->fatal($tnfe, "Don't know how to build task '$task_name'\n", $trace);
+            $this->fatal($tnfe, sprintf("Don't know how to build task '%s'\n", $tnfe->getTaskName()), $trace);
         } catch (Exception $e) {
             $this->fatal($e, null, $trace);
         }


### PR DESCRIPTION
Fixes #58 by making sure to use the task name as provided by TaskNotFoundException.