### PR TITLE
Suppress return type compatibility deprecation notice - related to php 8.1

### DIFF
--- a/lib/phake/Application.php
+++ b/lib/phake/Application.php
@@ -58,22 +58,27 @@ class Application implements \ArrayAccess, \IteratorAggregate
         $this->args = $args;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetExists($k) {
         return array_key_exists($k, $this->args);
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetGet($k) {
         return isset($this->args[$k]) ? $this->args[$k] : null;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetSet($k, $v) {
         $this->args[$k] = $v;
     }
 
+    #[\ReturnTypeWillChange]
     public function offsetUnset($k) {
         unset($this->args[$k]);
     }
 
+    #[\ReturnTypeWillChange]
     public function getIterator() {
         return new \ArrayIterator($this->args);
     }


### PR DESCRIPTION
I am using #[\ReturnTypeWillChange] to suppress deprecation notices raised while using the code at phake/lib/phake/Application.php. [Reference link]([url](https://www.php.net/manual/en/class.returntypewillchange.php)).

The following is one of the notices received:
Deprecated: Return type of getIterator() should either be compatible with IteratorAggregate::getIterator(): Traversable, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /var/www/html/phake/lib/phake/Application.php on line 77
